### PR TITLE
Set baseUrl to ../../

### DIFF
--- a/frontend/typescript/tsconfig.dts.json
+++ b/frontend/typescript/tsconfig.dts.json
@@ -19,7 +19,10 @@
             "../../bazel-out/k8-dbg/bin",
             "../../bazel-out/x64_windows-dbg/bin",
         ],
-        "baseUrl": ".",
+        
+        // https://www.typescriptlang.org/docs/handbook/module-resolution.html#base-ur
+        "baseUrl": "../../",
+        
         "paths": {
             ":*": [
                 "./frontend/*",


### PR DESCRIPTION
This fixes the TypeScript build when running

```
bazel build //frontend/project-a:tsconfig
```